### PR TITLE
Hide BLAS and LAPACK symbols

### DIFF
--- a/include/qpOASES/LapackBlasReplacement.hpp
+++ b/include/qpOASES/LapackBlasReplacement.hpp
@@ -40,42 +40,42 @@
 #ifdef __USE_SINGLE_PRECISION__
 
 	/** Macro for calling level 3 BLAS operation in single precision. */
-	#define GEMM sgemm_
+	#define GEMM qpOASES_sgemm_
 	/** Macro for calling level 3 BLAS operation in single precision. */
-	#define SYR ssyr_
+	#define SYR qpOASES_ssyr_
 	/** Macro for calling level 3 BLAS operation in single precision. */
-	#define SYR2 ssyr2_
+	#define SYR2 qpOASES_ssyr2_
 	/** Macro for calling level 3 BLAS operation in single precision. */
-	#define POTRF spotrf_
+	#define POTRF qpOASES_spotrf_
 
 	/** Macro for calling level 3 BLAS operation in single precision. */
 	/* #define GEQRF sgeqrf_ */
 	/** Macro for calling level 3 BLAS operation in single precision. */
 	/* #define ORMQR sormqr_ */
 	/** Macro for calling level 3 BLAS operation in single precision. */
-	#define TRTRS strtrs_
+	#define TRTRS qpOASES_strtrs_
 	/** Macro for calling level 3 BLAS operation in single precision. */
-	#define TRCON strcon_
+	#define TRCON qpOASES_strcon_
 
 #else
 
 	/** Macro for calling level 3 BLAS operation in double precision. */
-	#define GEMM dgemm_
+	#define GEMM qpOASES_dgemm_
 	/** Macro for calling level 3 BLAS operation in double precision. */
-	#define SYR  dsyr_
+	#define SYR  qpOASES_dsyr_
 	/** Macro for calling level 3 BLAS operation in double precision. */
-	#define SYR2 dsyr2_
+	#define SYR2 qpOASES_dsyr2_
 	/** Macro for calling level 3 BLAS operation in double precision. */
-	#define POTRF dpotrf_
+	#define POTRF qpOASES_dpotrf_
 
 	/** Macro for calling level 3 BLAS operation in double precision. */
 	/* #define GEQRF dgeqrf_ */
 	/** Macro for calling level 3 BLAS operation in double precision. */
 	/* #define ORMQR dormqr_ */
 	/** Macro for calling level 3 BLAS operation in double precision. */
-	#define TRTRS dtrtrs_
+	#define TRTRS qpOASES_dtrtrs_
 	/** Macro for calling level 3 BLAS operation in double precision. */
-	#define TRCON dtrcon_
+	#define TRCON qpOASES_dtrcon_
 
 #endif /* __USE_SINGLE_PRECISION__ */
 
@@ -83,32 +83,32 @@
 extern "C"
 {
 	/** Performs one of the matrix-matrix operation in double precision. */
-	void dgemm_(	const char*, const char*, const la_uint_t*, const la_uint_t*, const la_uint_t*,
+	void qpOASES_dgemm_(	const char*, const char*, const la_uint_t*, const la_uint_t*, const la_uint_t*,
 					const double*, const double*, const la_uint_t*, const double*, const la_uint_t*,
 					const double*, double*, const la_uint_t* );
 	/** Performs one of the matrix-matrix operation in single precision. */
-	void sgemm_(	const char*, const char*, const la_uint_t*, const la_uint_t*, const la_uint_t*,
+	void qpOASES_sgemm_(	const char*, const char*, const la_uint_t*, const la_uint_t*, const la_uint_t*,
 					const float*, const float*, const la_uint_t*, const float*, const la_uint_t*,
 					const float*, float*, const la_uint_t* );
 
 	/** Performs a symmetric rank 1 operation in double precision. */
-	void dsyr_(		const char*, const la_uint_t*, const double*, const double*,
+	void qpOASES_dsyr_(		const char*, const la_uint_t*, const double*, const double*,
 					const la_uint_t*, double*, const la_uint_t* );
 	/** Performs a symmetric rank 1 operation in single precision. */
-	void ssyr_(		const char*, const la_uint_t*, const float*, const float*,
+	void qpOASES_ssyr_(		const char*, const la_uint_t*, const float*, const float*,
 					const la_uint_t*, float*, const la_uint_t* );
 
 	/** Performs a symmetric rank 2 operation in double precision. */
-	void dsyr2_(	const char*, const la_uint_t*, const double*, const double*,
+	void qpOASES_dsyr2_(	const char*, const la_uint_t*, const double*, const double*,
 					const la_uint_t*, const double*, const la_uint_t*, double*, const la_uint_t*);
 	/** Performs a symmetric rank 2 operation in single precision. */
-	void ssyr2_(	const char*, const la_uint_t*, const float*, const float*,
+	void qpOASES_ssyr2_(	const char*, const la_uint_t*, const float*, const float*,
 					const la_uint_t*, const float*, const la_uint_t*, float*, const la_uint_t*);
 
 	/** Calculates the Cholesky factorization of a real symmetric positive definite matrix in double precision. */
-	void dpotrf_(	const char*, const la_uint_t*, double*, const la_uint_t*, la_int_t* );
+	void qpOASES_dpotrf_(	const char*, const la_uint_t*, double*, const la_uint_t*, la_int_t* );
 	/** Calculates the Cholesky factorization of a real symmetric positive definite matrix in single precision. */
-	void spotrf_(	const char*, const la_uint_t*, float*, const la_uint_t*, la_int_t* );
+	void qpOASES_spotrf_(	const char*, const la_uint_t*, float*, const la_uint_t*, la_int_t* );
 
 
 	/** Computes a QR factorization of a real M-by-N matrix A in double precision */
@@ -128,17 +128,17 @@ extern "C"
 						float* WORK, const la_uint_t* LWORK, int *INFO );*/
 
 	/** Solves a triangular system (double precision) */
-	void dtrtrs_(	const char* UPLO, const char* TRANS, const char* DIAG, const la_uint_t* N, const la_uint_t* NRHS,
+	void qpOASES_dtrtrs_(	const char* UPLO, const char* TRANS, const char* DIAG, const la_uint_t* N, const la_uint_t* NRHS,
 					double* A, const la_uint_t* LDA, double* B, const la_uint_t* LDB, la_int_t* INFO );
 	/** Solves a triangular system (single precision) */
-	void strtrs_(	const char* UPLO, const char* TRANS, const char* DIAG, const la_uint_t* N, const la_uint_t* NRHS,
+	void qpOASES_strtrs_(	const char* UPLO, const char* TRANS, const char* DIAG, const la_uint_t* N, const la_uint_t* NRHS,
 					float* A, const la_uint_t* LDA, float* B, const la_uint_t* LDB, la_int_t* INFO );
 
 	/** Estimate the reciprocal of the condition number of a triangular matrix in double precision */
-	void dtrcon_(	const char* NORM, const char* UPLO, const char* DIAG, const la_uint_t* N, double* A, const la_uint_t* LDA,
+	void qpOASES_dtrcon_(	const char* NORM, const char* UPLO, const char* DIAG, const la_uint_t* N, double* A, const la_uint_t* LDA,
 					double* RCOND, double* WORK, const la_uint_t* IWORK, la_int_t* INFO );
 	/** Estimate the reciprocal of the condition number of a triangular matrix in single precision */
-	void strcon_(	const char* NORM, const char* UPLO, const char* DIAG, const la_uint_t* N, float* A, const la_uint_t* LDA,
+	void qpOASES_strcon_(	const char* NORM, const char* UPLO, const char* DIAG, const la_uint_t* N, float* A, const la_uint_t* LDA,
 					float* RCOND, float* WORK, const la_uint_t* IWORK, la_int_t* INFO );
 }
 

--- a/src/BLASReplacement.cpp
+++ b/src/BLASReplacement.cpp
@@ -35,7 +35,7 @@
 #include <qpOASES/Utils.hpp>
 
 
-extern "C" void dgemm_(	const char* TRANSA, const char* TRANSB,
+extern "C" void qpOASES_dgemm_(	const char* TRANSA, const char* TRANSB,
 						const la_uint_t* M, const la_uint_t* N, const la_uint_t* K,
 						const double* ALPHA, const double* A, const la_uint_t* LDA, const double* B, const la_uint_t* LDB,
 						const double* BETA, double* C, const la_uint_t* LDC
@@ -90,7 +90,7 @@ extern "C" void dgemm_(	const char* TRANSA, const char* TRANSB,
 						C[j+(*LDC)*k] += *ALPHA * A[i+(*LDA)*j] * B[i+(*LDB)*k];
 }
 
-extern "C" void sgemm_(	const char* TRANSA, const char* TRANSB,
+extern "C" void qpOASES_sgemm_(	const char* TRANSA, const char* TRANSB,
 						const la_uint_t* M, const la_uint_t* N, const la_uint_t* K,
 						const float* ALPHA, const float* A, const la_uint_t* LDA, const float* B, const la_uint_t* LDB,
 						const float* BETA, float* C, const la_uint_t* LDC

--- a/src/LAPACKReplacement.cpp
+++ b/src/LAPACKReplacement.cpp
@@ -35,7 +35,7 @@
 #include <qpOASES/Utils.hpp>
 
 
-extern "C" void dpotrf_(	const char* uplo, const la_uint_t* _n, double* a,
+extern "C" void qpOASES_dpotrf_(	const char* uplo, const la_uint_t* _n, double* a,
 							const la_uint_t* _lda, la_int_t* info
 							)
 {
@@ -77,7 +77,7 @@ extern "C" void dpotrf_(	const char* uplo, const la_uint_t* _n, double* a,
 }
 
 
-extern "C" void spotrf_(	const char* uplo, const la_uint_t* _n, float* a,
+extern "C" void qpOASES_spotrf_(	const char* uplo, const la_uint_t* _n, float* a,
 							const la_uint_t* _lda, la_int_t* info
 							)
 {
@@ -118,7 +118,7 @@ extern "C" void spotrf_(	const char* uplo, const la_uint_t* _n, float* a,
 		*info = 0;
 }
 
-extern "C" void dtrtrs_(	const char* UPLO, const char* TRANS, const char* DIAG,
+extern "C" void qpOASES_dtrtrs_(	const char* UPLO, const char* TRANS, const char* DIAG,
 							const la_uint_t* N, const la_uint_t* NRHS,
 							double* A, const la_uint_t* LDA, double* B, const la_uint_t* LDB, la_int_t* INFO
 							)
@@ -126,7 +126,7 @@ extern "C" void dtrtrs_(	const char* UPLO, const char* TRANS, const char* DIAG,
 	INFO[0] = ((la_int_t)0xDEADBEEF); /* Dummy. If SQProblemSchur is to be used, system LAPACK must be used */
 }
 
-extern "C" void strtrs_(	const char* UPLO, const char* TRANS, const char* DIAG,
+extern "C" void qpOASES_strtrs_(	const char* UPLO, const char* TRANS, const char* DIAG,
 							const la_uint_t* N, const la_uint_t* NRHS,
 							float* A, const la_uint_t* LDA, float* B, const la_uint_t* LDB, la_int_t* INFO
 							)
@@ -134,7 +134,7 @@ extern "C" void strtrs_(	const char* UPLO, const char* TRANS, const char* DIAG,
 	INFO[0] = ((la_int_t)0xDEADBEEF); /* Dummy. If SQProblemSchur is to be used, system LAPACK must be used */
 }
 
-extern "C" void dtrcon_(	const char* NORM, const char* UPLO, const char* DIAG,
+extern "C" void qpOASES_dtrcon_(	const char* NORM, const char* UPLO, const char* DIAG,
 							const la_uint_t* N, double* A, const la_uint_t*LDA,
 							double* RCOND, double* WORK, const la_uint_t* IWORK, la_int_t* INFO
 							)
@@ -142,7 +142,7 @@ extern "C" void dtrcon_(	const char* NORM, const char* UPLO, const char* DIAG,
 	INFO[0] = ((la_int_t)0xDEADBEEF); /* Dummy. If SQProblemSchur is to be used, system LAPACK must be used */
 }
 
-extern "C" void strcon_(	const char* NORM, const char* UPLO, const char* DIAG,
+extern "C" void qpOASES_strcon_(	const char* NORM, const char* UPLO, const char* DIAG,
 							const la_uint_t* N, float* A, const la_uint_t* LDA,
 							float* RCOND, float* WORK, const la_uint_t* IWORK, la_int_t* INFO
 							)


### PR DESCRIPTION
qpOASES defines its own version of BLAS and LAPACK routines for internal use.
This is fine, but they should properly change the name of the symbols to avoid
collision with the actual BLAS and LAPACK functions in binaries that link both
qpOASES and the real BLAS and LAPACK functions.